### PR TITLE
Upgrade MiniMax default model to M3

### DIFF
--- a/role_play_data/README.md
+++ b/role_play_data/README.md
@@ -26,7 +26,7 @@ python role_generate.py
 
 
 2. 生成医患之间的多轮对话
-LLM选择：支持gpt-4o、豆包doubao-character-pro-32k、MiniMax-M2.7等多种LLM生成对话
+LLM选择：支持gpt-4o、豆包doubao-character-pro-32k、MiniMax-M3等多种LLM生成对话
 ```bash
 # 使用OpenAI GPT-4o
 python roleplay_data_generate_gpt4.py
@@ -39,7 +39,7 @@ export MINIMAX_API_KEY="your_api_key"
 python roleplay_data_generate_minimax.py
 
 # MiniMax支持自定义参数
-python roleplay_data_generate_minimax.py --model MiniMax-M2.5-highspeed --total 500 --rounds 8
+python roleplay_data_generate_minimax.py --model MiniMax-M2.7 --total 500 --rounds 8
 ```
 
 ### 多Provider支持
@@ -50,7 +50,7 @@ python roleplay_data_generate_minimax.py --model MiniMax-M2.5-highspeed --total 
 |----------|---------|---------|---------|
 | OpenAI | `OPENAI_API_KEY` | gpt-4o | https://api.openai.com/v1 |
 | 豆包 | `DOUBAO_API_KEY` | doubao-character-pro-32k | https://ark.cn-beijing.volces.com/api/v3 |
-| MiniMax | `MINIMAX_API_KEY` | MiniMax-M2.7 | https://api.minimax.io/v1 |
+| MiniMax | `MINIMAX_API_KEY` | MiniMax-M3 | https://api.minimax.io/v1 |
 
 ```python
 from llm_client import create_llm_client

--- a/role_play_data/llm_client.py
+++ b/role_play_data/llm_client.py
@@ -35,7 +35,7 @@ PROVIDER_CONFIGS = {
     "minimax": {
         "env_key": "MINIMAX_API_KEY",
         "base_url": "https://api.minimax.io/v1",
-        "default_model": "MiniMax-M2.7",
+        "default_model": "MiniMax-M3",
     },
 }
 

--- a/role_play_data/roleplay_data_generate_minimax.py
+++ b/role_play_data/roleplay_data_generate_minimax.py
@@ -3,14 +3,14 @@
 @description: Generate medical roleplay dialogue training data using MiniMax API.
 
 MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1
-with models like MiniMax-M2.7 (1M context) and MiniMax-M2.5-highspeed (204K context).
+with models like MiniMax-M3 (latest) and MiniMax-M2.7 (1M context).
 
 Usage:
     export MINIMAX_API_KEY="your_api_key"
     python roleplay_data_generate_minimax.py
 
     # Or specify a different model
-    python roleplay_data_generate_minimax.py --model MiniMax-M2.5-highspeed
+    python roleplay_data_generate_minimax.py --model MiniMax-M2.7
 
 For an API key, visit: https://platform.minimaxi.com/
 """
@@ -42,7 +42,7 @@ def generate(client, model, prompt, system_prompt=''):
 def main():
     parser = argparse.ArgumentParser(description="Generate roleplay data with MiniMax")
     parser.add_argument("--model", type=str, default=None,
-                        help="MiniMax model to use (default: MiniMax-M2.7)")
+                        help="MiniMax model to use (default: MiniMax-M3)")
     parser.add_argument("--total", type=int, default=1000,
                         help="Number of conversations to generate")
     parser.add_argument("--output", type=str, default="roleplay_train_data_minimax.jsonl",


### PR DESCRIPTION
## Summary

Upgrades the MiniMax provider default model in `role_play_data` to `MiniMax-M3` (the current latest), while keeping `MiniMax-M2.7` documented as an alternative.

## Changes

- `role_play_data/llm_client.py`: `default_model` switched from `MiniMax-M2.7` to `MiniMax-M3`.
- `role_play_data/roleplay_data_generate_minimax.py`: docstring + `--model` help reference M3 as default; the deprecated `MiniMax-M2.5-highspeed` example is replaced with `MiniMax-M2.7`.
- `role_play_data/README.md`: provider table and CLI examples updated to reflect M3 as default; `--model MiniMax-M2.7` shown as the override sample.

The base URL (`https://api.minimax.io/v1`), env var (`MINIMAX_API_KEY`), provider plumbing, and all other providers (OpenAI, Doubao) are untouched. Users who need the older 1M-context model can still pass `--model MiniMax-M2.7` or override `default_model` programmatically.

## Test

- `python3 -m py_compile` clean for both modified `.py` files.
- Manual import + config check: `PROVIDER_CONFIGS['minimax']['default_model'] == 'MiniMax-M3'`, `create_llm_client(provider='minimax')` returns `MiniMax-M3`, `create_llm_client(provider='minimax', model='MiniMax-M2.7')` still returns `MiniMax-M2.7`.
- Live API call against `https://api.minimax.io/v1` with `model=MiniMax-M3` reaches the model (the test key has zero credit balance, but the model name is accepted by the gateway, confirming `MiniMax-M3` is a valid identifier on the platform).